### PR TITLE
Session/8 NotificationCenter

### DIFF
--- a/iOS-study/WeatherViewController.swift
+++ b/iOS-study/WeatherViewController.swift
@@ -14,9 +14,17 @@ class WeatherViewController: UIViewController, WeatherServiceDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         weatherService = WeatherService()
         weatherService.delegate = self
+
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        
+        weatherService.fetchWeather()
+    }
+
+    @objc func appDidBecomeActive() {
+        weatherService.fetchWeather()
     }
     
     @IBOutlet weak var weatherImageView: UIImageView!

--- a/iOS-study/WeatherViewController.swift
+++ b/iOS-study/WeatherViewController.swift
@@ -18,12 +18,12 @@ class WeatherViewController: UIViewController, WeatherServiceDelegate {
         weatherService = WeatherService()
         weatherService.delegate = self
 
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshWeatherOnActive), name: UIApplication.didBecomeActiveNotification, object: nil)
         
         weatherService.fetchWeather()
     }
 
-    @objc func appDidBecomeActive() {
+    @objc func refreshWeatherOnActive() {
         weatherService.fetchWeather()
     }
     

--- a/iOS-study/WeatherViewController.swift
+++ b/iOS-study/WeatherViewController.swift
@@ -47,10 +47,12 @@ class WeatherViewController: UIViewController, WeatherServiceDelegate {
      }
     
     func didFailWithError(_ service: WeatherService, error: Error) {
-        let errorMessage = makeErrorMessage(error)
-        let alertController = UIAlertController(title: "Error", message: errorMessage, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        self.present(alertController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            let errorMessage = self.makeErrorMessage(error)
+            let alertController = UIAlertController(title: "Error", message: errorMessage, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
 
     func makeErrorMessage(_ error: Error) -> String {


### PR DESCRIPTION
## 概要
- NotificationCenterを利用して、アプリがバックグラウンドからフォアグラウンドに戻ってきたときに、天気予報を更新する
- バックグラウンドからフォアグラウンドに戻ってきたときに、エラーになる場合はアラートが表示されるように修正

https://github.com/ryoryo3939/iOS-study/assets/110385079/be5b794f-846e-4feb-95cb-2af76d4cc30f

